### PR TITLE
Add Value Monad for Expectations

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -25,6 +25,9 @@ lib/generators/minitest/install/templates/test_helper.rb
 lib/generators/minitest/integration/integration_generator.rb
 lib/generators/minitest/integration/templates/integration_spec.rb
 lib/generators/minitest/integration/templates/integration_test.rb
+lib/generators/minitest/job/job_generator.rb
+lib/generators/minitest/job/templates/job_spec.rb
+lib/generators/minitest/job/templates/job_test.rb
 lib/generators/minitest/mailer/mailer_generator.rb
 lib/generators/minitest/mailer/templates/mailer_spec.rb
 lib/generators/minitest/mailer/templates/mailer_test.rb
@@ -52,6 +55,7 @@ test/generators/test_controller_generator.rb
 test/generators/test_generator_generator.rb
 test/generators/test_helper_generator.rb
 test/generators/test_install_generator.rb
+test/generators/test_job_generator.rb
 test/generators/test_mailer_generator.rb
 test/generators/test_model_generator.rb
 test/generators/test_route_generator.rb
@@ -66,6 +70,9 @@ test/rails/action_mailer/test_mailers.rb
 test/rails/action_mailer/test_spec_type.rb
 test/rails/action_view/test_helpers.rb
 test/rails/action_view/test_spec_type.rb
+test/rails/active_job/test_assertions.rb
+test/rails/active_job/test_expectations.rb
+test/rails/active_job/test_spec_type.rb
 test/rails/active_support/test_assertions.rb
 test/rails/active_support/test_expectations.rb
 test/rails/active_support/test_spec_type.rb

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ Hoe.spec "minitest-rails" do
 
   license "MIT"
 
-  dependency "minitest", "~> 5.4"
+  dependency "minitest", "~> 5.6"
   dependency "railties", "~> 4.1"
   dependency "fakefs",   "= 0.4.3", :dev
 end

--- a/lib/generators/minitest/controller/templates/controller_spec.rb
+++ b/lib/generators/minitest/controller/templates/controller_spec.rb
@@ -10,7 +10,7 @@ describe <%= class_name %>Controller do
 <% actions.each do |action| -%>
   it "should get <%= action %>" do
     get :<%= action %>
-    assert_response :success
+    value(response).must_be :success?
   end
 
 <% end -%>

--- a/lib/generators/minitest/helper/templates/helper_spec.rb
+++ b/lib/generators/minitest/helper/templates/helper_spec.rb
@@ -2,10 +2,8 @@ require "test_helper"
 
 <% module_namespacing do -%>
 describe <%= class_name %>Helper do
-
   it "must be a real test" do
     flunk "Need real tests"
   end
-
 end
 <% end -%>

--- a/lib/generators/minitest/helper/templates/helper_test.rb
+++ b/lib/generators/minitest/helper/templates/helper_test.rb
@@ -2,10 +2,8 @@ require "test_helper"
 
 <% module_namespacing do -%>
 class <%= class_name %>HelperTest < ActionView::TestCase
-
   def test_sanity
     flunk "Need real tests"
   end
-
 end
 <% end -%>

--- a/lib/generators/minitest/job/templates/job_spec.rb
+++ b/lib/generators/minitest/job/templates/job_spec.rb
@@ -2,10 +2,8 @@ require "test_helper"
 
 <% module_namespacing do -%>
 describe <%= class_name %>Job do
-
   it "must be a real test" do
     flunk "Need real tests"
   end
-
 end
 <% end -%>

--- a/lib/generators/minitest/job/templates/job_test.rb
+++ b/lib/generators/minitest/job/templates/job_test.rb
@@ -2,10 +2,8 @@ require "test_helper"
 
 <% module_namespacing do -%>
 class <%= class_name %>JobTest < ActiveJob::TestCase
-
   def test_sanity
     flunk "Need real tests"
   end
-
 end
 <% end -%>

--- a/lib/generators/minitest/mailer/templates/mailer_spec.rb
+++ b/lib/generators/minitest/mailer/templates/mailer_spec.rb
@@ -5,10 +5,10 @@ describe <%= class_name %> do
 <% actions.each do |action| -%>
   it "<%= action %>" do
     mail = <%= class_name %>.<%= action %>
-    mail.subject.must_equal <%= action.to_s.humanize.inspect %>
-    mail.to.must_equal ["to@example.org"]
-    mail.from.must_equal ["from@example.com"]
-    mail.body.encoded.must_match "Hi"
+    value(mail.subject).must_equal <%= action.to_s.humanize.inspect %>
+    value(mail.to).must_equal ["to@example.org"]
+    value(mail.from).must_equal ["from@example.com"]
+    value(mail.body.encoded).must_match "Hi"
   end
 <% end -%>
 <% if actions.blank? -%>

--- a/lib/generators/minitest/model/templates/model_spec.rb
+++ b/lib/generators/minitest/model/templates/model_spec.rb
@@ -5,7 +5,7 @@ describe <%= class_name %> do
   let(:<%= file_name %>) { <%= class_name %>.new }
 
   it "must be valid" do
-    <%= file_name %>.must_be :valid?
+    value(<%= file_name %>).must_be :valid?
   end
 end
 <% end -%>

--- a/lib/generators/minitest/model/templates/model_test.rb
+++ b/lib/generators/minitest/model/templates/model_test.rb
@@ -2,7 +2,6 @@ require "test_helper"
 
 <% module_namespacing do -%>
 class <%= class_name %>Test < ActiveSupport::TestCase
-
   def <%= file_name %>
     @<%= file_name %> ||= <%= class_name %>.new
   end
@@ -10,6 +9,5 @@ class <%= class_name %>Test < ActiveSupport::TestCase
   def test_valid
     assert <%= file_name %>.valid?
   end
-
 end
 <% end -%>

--- a/lib/generators/minitest/route/templates/route_spec.rb
+++ b/lib/generators/minitest/route/templates/route_spec.rb
@@ -1,10 +1,13 @@
 require "test_helper"
 
 # Add the following to your Rake file to test routes by default:
-#   Minitest::Rails::Testing.default_tasks << "routes"
+#   Rails::TestTask.new("test:routes" => "test:prepare") do |t|
+#     t.pattern = "test/routes/**/*_test.rb"
+#   end
+#   Rake::Task["test:run"].enhance ["test:routes"]
 
 describe "Route Integration Test" do
   it "route root" do
-    assert_routing "/", controller: "home", action: "show"
+    must_route "/", controller: "home", action: "show"
   end
 end

--- a/lib/generators/minitest/route/templates/route_test.rb
+++ b/lib/generators/minitest/route/templates/route_test.rb
@@ -1,7 +1,10 @@
 require "test_helper"
 
 # Add the following to your Rake file to test routes by default:
-#   Minitest::Rails::Testing.default_tasks << "routes"
+#   Rails::TestTask.new("test:routes" => "test:prepare") do |t|
+#     t.pattern = "test/routes/**/*_test.rb"
+#   end
+#   Rake::Task["test:run"].enhance ["test:routes"]
 
 class RouteTest < ActionDispatch::IntegrationTest
   def test_root

--- a/lib/generators/minitest/scaffold/templates/controller_spec.rb
+++ b/lib/generators/minitest/scaffold/templates/controller_spec.rb
@@ -2,18 +2,17 @@ require "test_helper"
 
 <% module_namespacing do -%>
 describe <%= controller_class_name %>Controller do
-
   let(:<%= singular_table_name %>) { <%= table_name %> :one }
 
   it "gets index" do
     get :index
-    assert_response :success
-    assert_not_nil assigns(:<%= table_name %>)
+    value(response).must_be :success?
+    value(assigns(:<%= table_name %>)).wont_be :nil?
   end
 
   it "gets new" do
     get :new
-    assert_response :success
+    value(response).must_be :success?
   end
 
   it "creates <%= singular_table_name %>" do
@@ -21,22 +20,22 @@ describe <%= controller_class_name %>Controller do
       post :create, <%= "#{singular_table_name}: { #{attributes_hash} }" %>
     end
 
-    assert_redirected_to <%= singular_table_name %>_path(assigns(:<%= singular_table_name %>))
+    must_redirect_to <%= singular_table_name %>_path(assigns(:<%= singular_table_name %>))
   end
 
   it "shows <%= singular_table_name %>" do
     get :show, id: <%= singular_table_name %>
-    assert_response :success
+    value(response).must_be :success?
   end
 
   it "gets edit" do
     get :edit, id: <%= singular_table_name %>
-    assert_response :success
+    value(response).must_be :success?
   end
 
   it "updates <%= singular_table_name %>" do
     put :update, id: <%= singular_table_name %>, <%= "#{singular_table_name}: { #{attributes_hash} }" %>
-    assert_redirected_to <%= singular_table_name %>_path(assigns(:<%= singular_table_name %>))
+    must_redirect_to <%= singular_table_name %>_path(assigns(:<%= singular_table_name %>))
   end
 
   it "destroys <%= singular_table_name %>" do
@@ -44,8 +43,7 @@ describe <%= controller_class_name %>Controller do
       delete :destroy, id: <%= singular_table_name %>
     end
 
-    assert_redirected_to <%= index_helper %>_path
+    must_redirect_to <%= index_helper %>_path
   end
-
 end
 <% end -%>

--- a/lib/generators/minitest/scaffold/templates/controller_test.rb
+++ b/lib/generators/minitest/scaffold/templates/controller_test.rb
@@ -2,7 +2,6 @@ require "test_helper"
 
 <% module_namespacing do -%>
 class <%= controller_class_name %>ControllerTest < ActionController::TestCase
-
   def <%= singular_table_name %>
     @<%= singular_table_name %> ||= <%= table_name %> :one
   end

--- a/lib/minitest/rails/expectations.rb
+++ b/lib/minitest/rails/expectations.rb
@@ -9,10 +9,10 @@ module Minitest::Rails::Expectations
   ##
   # Checks the numeric difference between the return value of an expression as a result of what is evaluated.
   #
-  #     lambda { User.create password: "valid" }.must_change "User.count"
-  #     lambda { 3.times do
-  #            User.create password: "valid"
-  #          end }.must_change "User.count", 3
+  #     value { User.create password: "valid" }.must_change "User.count"
+  #     value { 3.times do
+  #               User.create password: "valid"
+  #             end }.must_change "User.count", 3
   #
   # See also ActiveSupport::TestCase#assert_difference
   #
@@ -23,7 +23,7 @@ module Minitest::Rails::Expectations
   ##
   # Checks that the numeric result of evaluating an expression is not changed before and after invoking.
   #
-  #     lambda { User.new }.wont_change "User.count"
+  #     value { User.new }.wont_change "User.count"
   #
   # See also ActiveSupport::TestCase#refute_difference
   #
@@ -48,11 +48,11 @@ module Minitest::Rails::Expectations
   #
   #     # expect that the response was a redirection
   #     must_respond_with :redirect
-  #     response.must_respond_with :redirect
+  #     value(response).must_respond_with :redirect
   #
   #     # expect that the response code was status code 401 (unauthorized)
   #     must_respond_with 401
-  #     response.must_respond_with 401
+  #     value(response).must_respond_with 401
   #
   # See also ActionController::TestCase#assert_response
   # See also ActionView::TestCase#assert_response
@@ -130,16 +130,16 @@ module Minitest::Rails::Expectations
   # The +defaults+ parameter is unused.
   #
   #   # Expects that the default action is generated for a route with no action
-  #   {controller: "items", action: "index"}.must_route_from "/items"
+  #   value({controller: "items", action: "index"}).must_route_from "/items"
   #
   #   # Tests that the list action is properly routed
-  #   {controller: "items", action: "list"}.must_route_to "/items/list"
+  #   value({controller: "items", action: "list"}).must_route_to "/items/list"
   #
   #   # Tests the generation of a route with a parameter
-  #   { controller: "items", action: "list", id: "1" }.must_route_from "/items/list/1"
+  #   value({ controller: "items", action: "list", id: "1" }).must_route_from "/items/list/1"
   #
   #   # Expects that the generated route gives us our custom route
-  #   { controller: 'scm', action: 'show_diff', revision: "12" }.must_route_from "changesets/12"
+  #   value({ controller: 'scm', action: 'show_diff', revision: "12" }).must_route_from "changesets/12"
   #
   # See also ActionController::TestCase#assert_generates
   # See also ActionView::TestCase#assert_generates
@@ -165,21 +165,21 @@ module Minitest::Rails::Expectations
   # extras argument, appending the query string on the path directly will not work. For example:
   #
   #   # Expect that a path of '/items/list/1?view=print' returns the correct options
-  #   'items/list/1'.must_route_from({controller: 'items', action: 'list', id: '1', view: 'print'}, { view: "print" })
+  #   value('items/list/1').must_route_from({controller: 'items', action: 'list', id: '1', view: 'print'}, { view: "print" })
   #
   # The +message+ parameter allows you to pass in an error message that is displayed upon failure.
   #
   #   # Check the default route (i.e., the index action)
-  #   'items'.must_route_from({controller: 'items', action: 'index'})
+  #   value('items').must_route_from({controller: 'items', action: 'index'})
   #
   #   # Test a specific action
-  #   'items/list'.must_route_from({controller: 'items', action: 'list'})
+  #   value('items/list').must_route_from({controller: 'items', action: 'list'})
   #
   #   # Test an action with a parameter
-  #   'items/destroy/1'.must_route_from({controller: 'items', action: 'destroy', id: '1'})
+  #   value('items/destroy/1').must_route_from({controller: 'items', action: 'destroy', id: '1'})
   #
   #   # Test a custom route
-  #   'view/item1'.must_route_from({controller: 'items', action: 'show', id: '1'})
+  #   value('view/item1').must_route_from({controller: 'items', action: 'show', id: '1'})
   #
   # See also ActionController::TestCase#assert_recognizes
   # See also ActionView::TestCase#assert_recognizes
@@ -198,19 +198,19 @@ module Minitest::Rails::Expectations
   # +message+ parameter allows you to specify a custom error message to display upon failure.
   #
   #  # Expect a basic route: a controller with the default action (index)
-  #  { controller: 'home', action: 'index' }.must_route_for '/home'
+  #  value({ controller: 'home', action: 'index' }).must_route_for '/home'
   #
   #  # Test a route generated with a specific controller, action, and parameter (id)
-  #  { controller: 'entries', action: 'show', id: 23 }.must_route_for '/entries/show/23'
+  #  value({ controller: 'entries', action: 'show', id: 23 }).must_route_for '/entries/show/23'
   #
   #  # Expect a basic route (controller + default action), with an error message if it fails
-  #  { controller: 'store', action: 'index' }.must_route_for '/store'
+  #  value({ controller: 'store', action: 'index' }).must_route_for '/store'
   #
   #  # Tests a route, providing a defaults hash
-  #  {id: "9", item: "square"}.must_route_for 'controller/action/9', {controller: "controller", action: "action"}, {}, {item: "square"}
+  #  value({id: "9", item: "square"}).must_route_for 'controller/action/9', {controller: "controller", action: "action"}, {}, {item: "square"}
   #
   #  # Tests a route with a HTTP method
-  #  { controller: "product", action: "update", id: "321" }.must_route_for({ method: 'put', path: '/product/321' })
+  #  value({ controller: "product", action: "update", id: "321" }).must_route_for({ method: 'put', path: '/product/321' })
   #
   # See also ActionController::TestCase#assert_routing
   # See also ActionView::TestCase#assert_routing
@@ -383,7 +383,7 @@ module Minitest::Rails::Expectations
   # Checks the numeric difference between the return value of an expression as a result of what is evaluated.
   #
   #     apple_link = '<a href="http://www.example.com">Apples</a>'
-  #     link_to("Apples", "http://www.example.com").must_dom_equal apple_link
+  #     value(link_to("Apples", "http://www.example.com")).must_dom_equal apple_link
   #
   # See also ActionController::TestCase#assert_dom_equal
   # See also ActionView::TestCase#assert_dom_equal

--- a/minitest-rails.gemspec
+++ b/minitest-rails.gemspec
@@ -1,14 +1,14 @@
 # -*- encoding: utf-8 -*-
-# stub: minitest-rails 2.1.1.20141204135428 ruby lib
+# stub: minitest-rails 2.1.1.20150427085343 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "minitest-rails"
-  s.version = "2.1.1.20141204135428"
+  s.version = "2.1.1.20150427085343"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["Mike Moore"]
-  s.date = "2014-12-04"
+  s.date = "2015-04-27"
   s.description = "Adds Minitest as the default testing library in Rails"
   s.email = ["mike@blowmage.com"]
   s.extra_rdoc_files = ["CHANGELOG.rdoc", "Manifest.txt", "README.rdoc"]
@@ -16,28 +16,28 @@ Gem::Specification.new do |s|
   s.homepage = "http://blowmage.com/minitest-rails"
   s.licenses = ["MIT"]
   s.rdoc_options = ["--main", "README.rdoc"]
-  s.rubygems_version = "2.2.2"
+  s.rubygems_version = "2.4.6"
   s.summary = "Minitest integration for Rails"
-  s.test_files = ["test/generators/test_controller_generator.rb", "test/generators/test_generator_generator.rb", "test/generators/test_helper_generator.rb", "test/generators/test_install_generator.rb", "test/generators/test_job_generator.rb", "test/generators/test_mailer_generator.rb", "test/generators/test_model_generator.rb", "test/generators/test_route_generator.rb", "test/generators/test_scaffold_generator.rb", "test/rails/action_controller/test_assertions.rb", "test/rails/action_controller/test_controllers.rb", "test/rails/action_controller/test_expectations.rb", "test/rails/action_controller/test_spec_type.rb", "test/rails/action_dispatch/test_spec_type.rb", "test/rails/active_job/test_assertions.rb", "test/rails/active_job/test_expectations.rb", "test/rails/active_job/test_spec_type.rb", "test/rails/action_mailer/test_mailers.rb", "test/rails/action_mailer/test_spec_type.rb", "test/rails/action_view/test_helpers.rb", "test/rails/action_view/test_spec_type.rb", "test/rails/active_support/test_assertions.rb", "test/rails/active_support/test_expectations.rb", "test/rails/active_support/test_spec_type.rb", "test/rails/generators/test_spec_type.rb", "test/rails/test_constant_lookup.rb", "test/test_sanity.rb", "test/rails/minitest_5_api_test.rb"]
+  s.test_files = ["test/generators/test_controller_generator.rb", "test/generators/test_generator_generator.rb", "test/generators/test_helper_generator.rb", "test/generators/test_install_generator.rb", "test/generators/test_job_generator.rb", "test/generators/test_mailer_generator.rb", "test/generators/test_model_generator.rb", "test/generators/test_route_generator.rb", "test/generators/test_scaffold_generator.rb", "test/rails/action_controller/test_assertions.rb", "test/rails/action_controller/test_controllers.rb", "test/rails/action_controller/test_expectations.rb", "test/rails/action_controller/test_spec_type.rb", "test/rails/action_dispatch/test_spec_type.rb", "test/rails/action_mailer/test_mailers.rb", "test/rails/action_mailer/test_spec_type.rb", "test/rails/action_view/test_helpers.rb", "test/rails/action_view/test_spec_type.rb", "test/rails/active_job/test_assertions.rb", "test/rails/active_job/test_expectations.rb", "test/rails/active_job/test_spec_type.rb", "test/rails/active_support/test_assertions.rb", "test/rails/active_support/test_expectations.rb", "test/rails/active_support/test_spec_type.rb", "test/rails/generators/test_spec_type.rb", "test/rails/test_constant_lookup.rb", "test/test_sanity.rb", "test/rails/minitest_5_api_test.rb"]
 
   if s.respond_to? :specification_version then
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<minitest>, ["~> 5.4"])
+      s.add_runtime_dependency(%q<minitest>, ["~> 5.6"])
       s.add_runtime_dependency(%q<railties>, ["~> 4.1"])
       s.add_development_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_development_dependency(%q<fakefs>, ["= 0.4.3"])
       s.add_development_dependency(%q<hoe>, ["~> 3.13"])
     else
-      s.add_dependency(%q<minitest>, ["~> 5.4"])
+      s.add_dependency(%q<minitest>, ["~> 5.6"])
       s.add_dependency(%q<railties>, ["~> 4.1"])
       s.add_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_dependency(%q<fakefs>, ["= 0.4.3"])
       s.add_dependency(%q<hoe>, ["~> 3.13"])
     end
   else
-    s.add_dependency(%q<minitest>, ["~> 5.4"])
+    s.add_dependency(%q<minitest>, ["~> 5.6"])
     s.add_dependency(%q<railties>, ["~> 4.1"])
     s.add_dependency(%q<rdoc>, ["~> 4.0"])
     s.add_dependency(%q<fakefs>, ["= 0.4.3"])

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -45,6 +45,7 @@ require "rails/test_help"
 
 module TestApp
   class Application < ::Rails::Application
+    config.active_support.test_order = :random
     config.secret_key_base = "abc123"
   end
 end

--- a/test/rails/action_controller/test_expectations.rb
+++ b/test/rails/action_controller/test_expectations.rb
@@ -6,6 +6,7 @@ class TestActionControllerExpectations < ActionController::TestCase
   def test_must_respond_with
     get :index
     must_respond_with :success
+    value(response).must_be :success?
   end
 
   def test_must_redirect_to
@@ -21,9 +22,9 @@ class TestActionControllerExpectations < ActionController::TestCase
   def test_routing_expectations
     params = { :controller => "models", :action => "index" }
     path = "/models"
-    params.must_route_to path
-    path.must_route_from params
-    params.must_route_for path
+    value(params).must_route_to path
+    value(path).must_route_from params
+    value(params).must_route_for path
   end
 
   def test_must_dom_equal
@@ -31,8 +32,8 @@ class TestActionControllerExpectations < ActionController::TestCase
     apple_link2 = '<a target="_blank" href="http://www.example.com">Apples</a>'
     orange_link = '<a href="http://www.example.com">Oranges</a>'
 
-    apple_link.must_dom_equal apple_link2
-    apple_link.wont_dom_equal orange_link
+    value(apple_link).must_dom_equal apple_link2
+    value(apple_link).wont_dom_equal orange_link
   end
 
   def test_must_select

--- a/test/rails/active_support/test_expectations.rb
+++ b/test/rails/active_support/test_expectations.rb
@@ -6,16 +6,16 @@ class TestActiveSupportExpectations < ActiveSupport::TestCase
   def test_must_change
     counter = 0
 
-    lambda { counter += 1 }.must_change "counter", +1
+    value { counter += 1 }.must_change "counter", +1
 
-    lambda { counter += 3 }.must_change "counter", +3
+    value { counter += 3 }.must_change "counter", +3
 
-    lambda { counter -= 1 }.must_change "counter", -1
+    value { counter -= 1 }.must_change "counter", -1
   end
 
   def test_wont_change
     counter = 0
 
-    lambda { counter = 0 }.wont_change "counter"
+    value { counter = 0 }.wont_change "counter"
   end
 end


### PR DESCRIPTION
Update the generators and tests to use the new value monad in Minitest 5.6.

This means that instead of calling expectations directly on the objects:

```ruby
model = Model.new name: "thing"
model.must_be :valid?
```

You wrap the object in the `value` method. (Or you can use the `_` or `expect` methods.):

```ruby
model = Model.new name: "thing"
value(model).must_be :valid?
```

The `value` method (and `_`/`expect` methods) also take a block, so instead of calling the expectation on the block:

```ruby
lambda { model.save }.must_change "Model.count", +1
```

You pass the block to `value` and call the expectation on the return object.

```ruby
value { model.save }.must_change "Model.count", +1
```

At some point this will be the default and calling expectations on every object will be deprecated.