### PR TITLE
fix link to fixtures doc in yaml generator

### DIFF
--- a/lib/generators/minitest/model/templates/fixtures.yml
+++ b/lib/generators/minitest/model/templates/fixtures.yml
@@ -1,5 +1,5 @@
 # Read about fixtures at
-# http://api.rubyonrails.org/classes/ActiveRecord/Fixtures.html
+# http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 <% unless attributes.empty? -%>
 one:


### PR DESCRIPTION
The link to the fixtures docs in the yaml generator 404s. The same change was made in Rails years back: https://github.com/rails/rails/commit/8564f0ae19493b8de35072bdbf2fc6251d2ec443