### PR TITLE
Switch to using the spec DSL by default

### DIFF
--- a/lib/generators/minitest.rb
+++ b/lib/generators/minitest.rb
@@ -3,7 +3,7 @@ require 'rails/generators/named_base'
 module Minitest
   module Generators
     class Base < ::Rails::Generators::NamedBase #:nodoc:
-      class_option :spec, type: :boolean, default: false,
+      class_option :spec, type: :boolean, default: true,
                           desc: "Use Minitest::Spec DSL"
 
       def self.default_source_root

--- a/test/generators/test_controller_generator.rb
+++ b/test/generators/test_controller_generator.rb
@@ -5,7 +5,7 @@ class TestControllerGenerator < GeneratorTest
 
   def test_controller_generator
     assert_output(/create  test\/controllers\/user_controller_test.rb/m) do
-      Minitest::Generators::ControllerGenerator.start ["user"]
+      Minitest::Generators::ControllerGenerator.start ["user", "--no-spec"]
     end
     assert File.exists? "test/controllers/user_controller_test.rb"
     contents = File.read "test/controllers/user_controller_test.rb"
@@ -14,7 +14,7 @@ class TestControllerGenerator < GeneratorTest
 
   def test_namespaced_controller_generator
     assert_output(/create  test\/controllers\/admin\/user_controller_test.rb/m) do
-      Minitest::Generators::ControllerGenerator.start ["admin/user"]
+      Minitest::Generators::ControllerGenerator.start ["admin/user", "--no-spec"]
     end
     assert File.exists? "test/controllers/admin/user_controller_test.rb"
     contents = File.read "test/controllers/admin/user_controller_test.rb"
@@ -26,7 +26,7 @@ class TestControllerGenerator < GeneratorTest
     Rails::Generators.namespace = TestApp
 
     assert_output(/create  test\/controllers\/test_app\/user_controller_test.rb/m) do
-      Minitest::Generators::ControllerGenerator.start ["user"]
+      Minitest::Generators::ControllerGenerator.start ["user", "--no-spec"]
     end
     assert File.exists? "test/controllers/test_app/user_controller_test.rb"
     contents = File.read "test/controllers/test_app/user_controller_test.rb"
@@ -39,7 +39,7 @@ class TestControllerGenerator < GeneratorTest
 
   def test_controller_generator_spec
     assert_output(/create  test\/controllers\/user_controller_test.rb/m) do
-      Minitest::Generators::ControllerGenerator.start ["user", "--spec"]
+      Minitest::Generators::ControllerGenerator.start ["user"]
     end
     assert File.exists? "test/controllers/user_controller_test.rb"
     contents = File.read "test/controllers/user_controller_test.rb"
@@ -48,7 +48,7 @@ class TestControllerGenerator < GeneratorTest
 
   def test_namespaced_controller_generator_spec
     assert_output(/create  test\/controllers\/admin\/user_controller_test.rb/m) do
-      Minitest::Generators::ControllerGenerator.start ["admin/user", "--spec"]
+      Minitest::Generators::ControllerGenerator.start ["admin/user"]
     end
     assert File.exists? "test/controllers/admin/user_controller_test.rb"
     contents = File.read "test/controllers/admin/user_controller_test.rb"

--- a/test/generators/test_generator_generator.rb
+++ b/test/generators/test_generator_generator.rb
@@ -5,7 +5,7 @@ class TestGeneratorGenerator < GeneratorTest
 
   def test_generator_generator
     assert_output(/create  test\/lib\/generators\/awesome_generator_test.rb/m) do
-      Minitest::Generators::GeneratorGenerator.start ["awesome"]
+      Minitest::Generators::GeneratorGenerator.start ["awesome", "--no-spec"]
     end
     assert File.exists? "test/lib/generators/awesome_generator_test.rb"
     contents = File.read "test/lib/generators/awesome_generator_test.rb"
@@ -14,7 +14,7 @@ class TestGeneratorGenerator < GeneratorTest
 
   def test_namespaced_generator_generator
     assert_output(/create  test\/lib\/generators\/rails\/awesome_generator_test.rb/m) do
-      Minitest::Generators::GeneratorGenerator.start ["rails/awesome"]
+      Minitest::Generators::GeneratorGenerator.start ["rails/awesome", "--no-spec"]
     end
     assert File.exists? "test/lib/generators/rails/awesome_generator_test.rb"
     contents = File.read "test/lib/generators/rails/awesome_generator_test.rb"
@@ -26,7 +26,7 @@ class TestGeneratorGenerator < GeneratorTest
     Rails::Generators.namespace = TestApp
 
     assert_output(/create  test\/lib\/generators\/test_app\/awesome_generator_test.rb/m) do
-      Minitest::Generators::GeneratorGenerator.start ["awesome"]
+      Minitest::Generators::GeneratorGenerator.start ["awesome", "--no-spec"]
     end
     assert File.exists? "test/lib/generators/test_app/awesome_generator_test.rb"
     contents = File.read "test/lib/generators/test_app/awesome_generator_test.rb"
@@ -39,7 +39,7 @@ class TestGeneratorGenerator < GeneratorTest
 
   def test_generator_generator_spec
     assert_output(/create  test\/lib\/generators\/awesome_generator_test.rb/m) do
-      Minitest::Generators::GeneratorGenerator.start ["awesome", "--spec"]
+      Minitest::Generators::GeneratorGenerator.start ["awesome"]
     end
     assert File.exists? "test/lib/generators/awesome_generator_test.rb"
     contents = File.read "test/lib/generators/awesome_generator_test.rb"
@@ -48,7 +48,7 @@ class TestGeneratorGenerator < GeneratorTest
 
   def test_namespaced_generator_generator_spec
     assert_output(/create  test\/lib\/generators\/rails\/awesome_generator_test.rb/m) do
-      Minitest::Generators::GeneratorGenerator.start ["rails/awesome", "--spec"]
+      Minitest::Generators::GeneratorGenerator.start ["rails/awesome"]
     end
     assert File.exists? "test/lib/generators/rails/awesome_generator_test.rb"
     contents = File.read "test/lib/generators/rails/awesome_generator_test.rb"

--- a/test/generators/test_helper_generator.rb
+++ b/test/generators/test_helper_generator.rb
@@ -5,28 +5,28 @@ class TestHelperGenerator < GeneratorTest
 
   def test_helper_generator
     refute_output(/create  test\/helpers\/user_helper_test.rb/m) do
-      Minitest::Generators::HelperGenerator.start ["user"]
+      Minitest::Generators::HelperGenerator.start ["user", "--no-spec"]
     end
     refute File.exists? "test/helpers/user_helper_test.rb"
   end
 
   def test_namespaced_helper_generator
     refute_output(/create  test\/helpers\/admin\/user_helper_test.rb/m) do
-      Minitest::Generators::HelperGenerator.start ["admin/user"]
+      Minitest::Generators::HelperGenerator.start ["admin/user", "--no-spec"]
     end
     refute File.exists? "test/helpers/admin/user_helper_test.rb"
   end
 
   def test_helper_generator_spec
     refute_output(/create  test\/helpers\/user_helper_test.rb/m) do
-      Minitest::Generators::HelperGenerator.start ["user", "--spec"]
+      Minitest::Generators::HelperGenerator.start ["user"]
     end
     refute File.exists? "test/helpers/user_helper_test.rb"
   end
 
   def test_namespaced_helper_generator_spec
     refute_output(/create  test\/helpers\/admin\/user_helper_test.rb/m) do
-      Minitest::Generators::HelperGenerator.start ["admin/user", "--spec"]
+      Minitest::Generators::HelperGenerator.start ["admin/user"]
     end
     refute File.exists? "test/helpers/admin/user_helper_test.rb"
   end

--- a/test/generators/test_job_generator.rb
+++ b/test/generators/test_job_generator.rb
@@ -7,7 +7,7 @@ if defined? ActiveJob # Rails 4.2 and later.
 
     def test_job_generator
       assert_output(/create  test\/jobs\/user_invite_job_test.rb/m) do
-        Minitest::Generators::JobGenerator.start ["user_invite"]
+        Minitest::Generators::JobGenerator.start ["user_invite", "--no-spec"]
       end
       assert File.exists? "test/jobs/user_invite_job_test.rb"
       contents = File.read "test/jobs/user_invite_job_test.rb"
@@ -16,7 +16,7 @@ if defined? ActiveJob # Rails 4.2 and later.
 
     def test_namespaced_job_generator
       assert_output(/create  test\/jobs\/admin\/user_invite_job_test.rb/m) do
-        Minitest::Generators::JobGenerator.start ["admin/user_invite"]
+        Minitest::Generators::JobGenerator.start ["admin/user_invite", "--no-spec"]
       end
       assert File.exists? "test/jobs/admin/user_invite_job_test.rb"
       contents = File.read "test/jobs/admin/user_invite_job_test.rb"
@@ -25,7 +25,7 @@ if defined? ActiveJob # Rails 4.2 and later.
 
     def test_job_generator_spec
       assert_output(/create  test\/jobs\/user_invite_job_test.rb/m) do
-        Minitest::Generators::JobGenerator.start ["user_invite", "--spec"]
+        Minitest::Generators::JobGenerator.start ["user_invite"]
       end
       assert File.exists? "test/jobs/user_invite_job_test.rb"
       contents = File.read "test/jobs/user_invite_job_test.rb"
@@ -34,7 +34,7 @@ if defined? ActiveJob # Rails 4.2 and later.
 
     def test_namespaced_job_generator_spec
       assert_output(/create  test\/jobs\/admin\/user_invite_job_test.rb/m) do
-        Minitest::Generators::JobGenerator.start ["admin/user_invite", "--spec"]
+        Minitest::Generators::JobGenerator.start ["admin/user_invite"]
       end
       assert File.exists? "test/jobs/admin/user_invite_job_test.rb"
       contents = File.read "test/jobs/admin/user_invite_job_test.rb"

--- a/test/generators/test_mailer_generator.rb
+++ b/test/generators/test_mailer_generator.rb
@@ -5,7 +5,7 @@ class TestMailerGenerator < GeneratorTest
 
   def test_mailer_generator
     assert_output(/create  test\/mailers\/notification_mailer_test.rb/m) do
-      Minitest::Generators::MailerGenerator.start ["notification"]
+      Minitest::Generators::MailerGenerator.start ["notification", "--no-spec"]
     end
     assert File.exists? "test/mailers/notification_mailer_test.rb"
     contents = File.read "test/mailers/notification_mailer_test.rb"
@@ -14,7 +14,7 @@ class TestMailerGenerator < GeneratorTest
 
   def test_namespaced_mailer_generator
     assert_output(/create  test\/mailers\/admin\/notification_mailer_test.rb/m) do
-      Minitest::Generators::MailerGenerator.start ["admin/notification"]
+      Minitest::Generators::MailerGenerator.start ["admin/notification", "--no-spec"]
     end
     assert File.exists? "test/mailers/admin/notification_mailer_test.rb"
     contents = File.read "test/mailers/admin/notification_mailer_test.rb"
@@ -23,7 +23,7 @@ class TestMailerGenerator < GeneratorTest
 
   def test_mailer_generator_spec
     assert_output(/create  test\/mailers\/notification_mailer_test.rb/m) do
-      Minitest::Generators::MailerGenerator.start ["notification", "welcome", "--spec"]
+      Minitest::Generators::MailerGenerator.start ["notification", "welcome"]
     end
     assert File.exists? "test/mailers/notification_mailer_test.rb"
     contents = File.read "test/mailers/notification_mailer_test.rb"
@@ -32,7 +32,7 @@ class TestMailerGenerator < GeneratorTest
 
   def test_namespaced_mailer_generator_spec
     assert_output(/create  test\/mailers\/admin\/notification_mailer_test.rb/m) do
-      Minitest::Generators::MailerGenerator.start ["admin/notification", "welcome", "--spec"]
+      Minitest::Generators::MailerGenerator.start ["admin/notification", "welcome"]
     end
     assert File.exists? "test/mailers/admin/notification_mailer_test.rb"
     contents = File.read "test/mailers/admin/notification_mailer_test.rb"

--- a/test/generators/test_model_generator.rb
+++ b/test/generators/test_model_generator.rb
@@ -5,7 +5,7 @@ class TestModelGenerator < GeneratorTest
 
   def test_model_generator
     assert_output(/create  test\/models\/user_test.rb/m) do
-      Minitest::Generators::ModelGenerator.start ["user"]
+      Minitest::Generators::ModelGenerator.start ["user", "--no-spec"]
     end
     assert File.exists? "test/models/user_test.rb"
     contents = File.read "test/models/user_test.rb"
@@ -14,7 +14,7 @@ class TestModelGenerator < GeneratorTest
 
   def test_namespaced_model_generator
     assert_output(/create  test\/models\/admin\/user_test.rb/m) do
-      Minitest::Generators::ModelGenerator.start ["admin/user"]
+      Minitest::Generators::ModelGenerator.start ["admin/user", "--no-spec"]
     end
     assert File.exists? "test/models/admin/user_test.rb"
     contents = File.read "test/models/admin/user_test.rb"
@@ -26,7 +26,7 @@ class TestModelGenerator < GeneratorTest
     Rails::Generators.namespace = TestApp
 
     assert_output(/create  test\/models\/test_app\/user_test.rb/m) do
-      Minitest::Generators::ModelGenerator.start ["user"]
+      Minitest::Generators::ModelGenerator.start ["user", "--no-spec"]
     end
     assert File.exists? "test/models/test_app/user_test.rb"
     contents = File.read "test/models/test_app/user_test.rb"
@@ -39,7 +39,7 @@ class TestModelGenerator < GeneratorTest
 
   def test_model_generator_spec
     assert_output(/create  test\/models\/user_test.rb/m) do
-      Minitest::Generators::ModelGenerator.start ["user", "--spec"]
+      Minitest::Generators::ModelGenerator.start ["user"]
     end
     assert File.exists? "test/models/user_test.rb"
     # assert File.exists? "test/fixtures/users.yml"
@@ -49,7 +49,7 @@ class TestModelGenerator < GeneratorTest
 
   def test_namespaced_model_generator_spec
     assert_output(/create  test\/models\/admin\/user_test.rb/m) do
-      Minitest::Generators::ModelGenerator.start ["admin/user", "--spec"]
+      Minitest::Generators::ModelGenerator.start ["admin/user"]
     end
     assert File.exists? "test/models/admin/user_test.rb"
     contents = File.read "test/models/admin/user_test.rb"
@@ -58,14 +58,14 @@ class TestModelGenerator < GeneratorTest
 
   def test_model_generator_fixture
     assert_output(/create  test\/fixtures\/users.yml/m) do
-      Minitest::Generators::ModelGenerator.start ["user"]
+      Minitest::Generators::ModelGenerator.start ["user", "--no-spec"]
     end
     assert File.exists? "test/fixtures/users.yml"
   end
 
   def test_namespaced_model_generator_fixture
     assert_output(/create  test\/fixtures\/admin\/users.yml/m) do
-      Minitest::Generators::ModelGenerator.start ["admin/user"]
+      Minitest::Generators::ModelGenerator.start ["admin/user", "--no-spec"]
     end
     assert File.exists? "test/fixtures/admin/users.yml"
   end

--- a/test/generators/test_scaffold_generator.rb
+++ b/test/generators/test_scaffold_generator.rb
@@ -5,7 +5,7 @@ class TestScaffoldGenerator < GeneratorTest
 
   def test_scaffold_generator
     assert_output(/create  test\/controllers\/users_controller_test.rb/m) do
-      Minitest::Generators::ScaffoldGenerator.start ["User", "name:string", "email:string"]
+      Minitest::Generators::ScaffoldGenerator.start ["User", "name:string", "email:string", "--no-spec"]
     end
     assert File.exists? "test/controllers/users_controller_test.rb"
     contents = File.read "test/controllers/users_controller_test.rb"
@@ -15,7 +15,7 @@ class TestScaffoldGenerator < GeneratorTest
 
   def test_scaffold_generator_spec
     assert_output(/create  test\/controllers\/users_controller_test.rb/m) do
-      Minitest::Generators::ScaffoldGenerator.start ["User", "name:string", "email:string", "--spec"]
+      Minitest::Generators::ScaffoldGenerator.start ["User", "name:string", "email:string"]
     end
     assert File.exists? "test/controllers/users_controller_test.rb"
     contents = File.read "test/controllers/users_controller_test.rb"


### PR DESCRIPTION
At this point the main feature left in minitest-rails is the spec DSL.
Most other features were removed in 2.0. Let's change the default in 3.0.

Feedback wanted.