### PR TITLE
Change default spec class to ActiveSupport::TestCase

### DIFF
--- a/lib/minitest/rails.rb
+++ b/lib/minitest/rails.rb
@@ -40,6 +40,7 @@ class ActiveSupport::TestCase
 end
 
 class ActiveSupport::TestCase
+  register_spec_type(//, self)
   if defined?(ActiveRecord::Base)
     # Use AS::TestCase for the base class when describing a model
     register_spec_type(self) do |desc|

--- a/test/rails/active_support/test_spec_type.rb
+++ b/test/rails/active_support/test_spec_type.rb
@@ -8,16 +8,12 @@ class TestActiveSupportSpecType < Minitest::Test
     assert_equal ActiveSupport::TestCase, actual
   end
 
-  def refute_support actual
-    refute_equal ActiveSupport::TestCase, actual
-  end
-
   def test_spec_type_resolves_for_actitive_record_constants
     assert_support Minitest::Spec.spec_type(SomeRandomModel)
   end
 
   def test_spec_type_doesnt_resolve_random_strings
-    refute_support Minitest::Spec.spec_type("Unmatched String")
+    assert_support Minitest::Spec.spec_type("Unmatched String")
   end
 
   def test_spec_type_resolves_for_additional_desc_model


### PR DESCRIPTION
When a spec does not match any of the more specific spec type matchers (eg: model, controller, etc.) then the tests currently fall back to a test class of `Minitest::Spec`.

As a developer using Rails, this can lead to some surprises when you unexpectedly lose some of the niceties of `ActiveSupport::TestCase` (such as transactional tests).

I realise that I'm directly altering an assertion of an existing test here, but what are the arguments against having all the tests for your Rails application subclass `ActiveSupport::TestCase`?