### PR TITLE
Fix for spec DSL using Rails parallelize

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ Lint/HandleExceptions:
 Metrics/AbcSize:
   Exclude:
     - lib/generators/**/*
+    - lib/minitest/rails/parallelize.rb
 Metrics/ClassLength:
   Enabled: false
 Metrics/LineLength:
@@ -32,6 +33,9 @@ Naming/MemoizedInstanceVariableName:
   Exclude:
     - lib/generators/**/*
 
+Style/AccessModifierDeclarations:
+  Exclude:
+    - lib/minitest/rails/parallelize.rb
 Style/Alias:
   EnforcedStyle: prefer_alias
 Style/CaseEquality:

--- a/lib/minitest/rails.rb
+++ b/lib/minitest/rails.rb
@@ -141,6 +141,12 @@ end
 require "minitest/rails/assertions"
 require "minitest/rails/expectations"
 
+################################################################################
+# Support Rails parallelize
+################################################################################
+
+require "minitest/rails/parallelize"
+
 # :stopdoc:
 
 ################################################################################

--- a/lib/minitest/rails/capybara.rb
+++ b/lib/minitest/rails/capybara.rb
@@ -1,3 +1,4 @@
+require "minitest/rails"
 require "capybara/minitest"
 require "capybara/minitest/spec"
 

--- a/lib/minitest/rails/parallelize.rb
+++ b/lib/minitest/rails/parallelize.rb
@@ -1,0 +1,41 @@
+require "pathname"
+require "rails"
+
+# :stopdoc:
+
+##
+# These changes are here to support the spec DSL when using Rails parallelize.
+# The issue is the spec DSL creates Class objects that are not assigned to
+# a Ruby constant. When those Class objects are passed through Drb they are
+# wrapped in a DrbObject and cannot be run. The solution is to assign each Class
+# object to a constant. Hopefully the constant name is consistent enough that
+# the constant can be passed across processes (or even machines).
+
+module Minitest
+  module Rails
+    ##
+    # This module is a placeholder for all the Test classes created using the
+    # spec DSL. Normally all classes are created but not assigned to a constant.
+    # This module is where constants will be created for these classes.
+    module SpecTests #:nodoc:
+    end
+  end
+end
+
+module Kernel #:nodoc:
+  alias describe_before_minitest_spec_constant_fix describe
+  private :describe_before_minitest_spec_constant_fix
+  def describe *args, &block
+    cls = describe_before_minitest_spec_constant_fix(*args, &block)
+    cls_const = "Test__#{cls.name.to_s.split(/\W/).reject(&:empty?).join('_'.freeze)}"
+    if block.source_location
+      source_path, line_num = block.source_location
+      source_path = Pathname.new(source_path).relative_path_from(Rails.root).to_s
+      source_path = source_path.split(/\W/).reject(&:empty?).join("_".freeze)
+      cls_const += "__#{source_path}__#{line_num}"
+    end
+    cls_const += "_1" while Minitest::Rails::SpecTests.const_defined? cls_const
+    Minitest::Rails::SpecTests.const_set cls_const, cls
+    cls
+  end
+end


### PR DESCRIPTION
This PR is an attempt to resolve issues when using the spec DSL and Rails 6.0's parallelize. The problem as described in #217 is spec DSL creates `Class` objects that are not assigned to a Ruby constant. When those `Class` objects are passed through `Drb` they are wrapped in a `DrbObject` and errors are raised when the test is run. The solution offered is to assign each `Class` object to a constant, so that constant is used when passing to `Drb`. Hopefully the name generated for the constant is consistent enough that it can be used across forked processes, or even separate processes running on different hardware.

[fix #217]