### PR TITLE
Use ~> to pin rails to minor version instead of specific patch version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source "http://rubygems.org"
 gemspec
 
 gem "irb"
-gem "rails", "7.0.0"
+gem "rails", "~> 7.0.0"
 gem "rake"
 gem "sqlite3"

--- a/gemfiles/rails-7.0.0.gemfile
+++ b/gemfiles/rails-7.0.0.gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 
 gem "minitest-rails", path: "../"
-gem "rails", "7.0.0"
+gem "rails", "~> 7.0.0"
 gem "rake"
 gem "sqlite3"
 

--- a/minitest-rails.gemspec
+++ b/minitest-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.5.0"
 
   gem.add_dependency "minitest", "~> 5.10"
-  gem.add_dependency "railties", "7.0.0"
+  gem.add_dependency "railties", "~> 7.0.0"
 
   gem.add_development_dependency "minitest-autotest", "~> 1.0"
   gem.add_development_dependency "minitest-focus", "~> 1.1"


### PR DESCRIPTION
In https://github.com/blowmage/minitest-rails/pull/232/files support for Rails 7.0.0 has been added. However, the version has been pinned specifically to version 7.0.0, hence this gem is currently not compatible with the newly released Rails 7.0.1.

This pull request fixes https://github.com/blowmage/minitest-rails/issues/234